### PR TITLE
kProcessor2 Integration

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,6 +1,9 @@
 name: cibuildwheel
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build_wheels:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -lstdc++fs -fPIC -lgomp -lrt
 add_subdirectory(lib/kProcessor)
 
 include_directories("${PROJECT_SOURCE_DIR}/lib/kProcessor/include/kProcessor")
+include_directories("${PROJECT_SOURCE_DIR}/lib/kProcessor/include/kProcessor/kDataframes")
 include_directories("${PROJECT_SOURCE_DIR}/lib/kProcessor/ThirdParty/MQF/include")
 
 set(kProcessor_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/lib/kProcessor/include" "${PROJECT_SOURCE_DIR}/lib/kProcessor/include/kProcessor")
@@ -31,6 +32,7 @@ include_directories(${kProcessor_INCLUDE_PATH})
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 include_directories("${PROJECT_SOURCE_DIR}/lib/argh")
+include_directories("${PROJECT_SOURCE_DIR}/lib/kProcessor/ThirdParty/caches/include")
 
 set(PHMAP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/lib/kProcessor/ThirdParty/kmerDecoder/lib/parallel-hashmap")
 include_directories("${PHMAP_INCLUDE_DIRS}")

--- a/include/kSpider.hpp
+++ b/include/kSpider.hpp
@@ -2,9 +2,11 @@
 #include <cstdint>
 #include "argh.h"
 #include <chrono>
-#include "colored_kDataFrame.hpp"
 #include "parallel_hashmap/phmap.h"
 #include <queue>
+#include <string>
+
+using namespace std;
 
 namespace kSpider {
 
@@ -19,4 +21,4 @@ namespace kSpider {
     void single_end_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, int downsampling_ration, bool remove_singletones);
     void protein_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, bool is_dayhoff, string output_prefix, int downsampling_ration = 1);
 
-};
+}

--- a/include/kSpider.hpp
+++ b/include/kSpider.hpp
@@ -17,8 +17,12 @@ namespace kSpider {
     void index_protein(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix);
     void index_dayhoff(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix);
     void index_datasets(string kfs_dir);
-    void paired_end_to_kDataFrame(string r1_file_name, string r2_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones);
-    void single_end_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, int downsampling_ration, bool remove_singletones);
-    void protein_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, bool is_dayhoff, string output_prefix, int downsampling_ration = 1);
+
+    // The new one (index priotiyQueue)
+    void datasets_indexing(string kfs_dir);
+
+    void paired_end_to_kDataFrame(string r1_file_name, string r2_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones, bool ondisk);
+    void single_end_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones, bool ondisk);
+    void protein_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, bool is_dayhoff, string output_prefix, int downsampling_ratio, bool ondisk);
 
 }

--- a/pykSpider/kSpider2/ks_dataset_indexing.py
+++ b/pykSpider/kSpider2/ks_dataset_indexing.py
@@ -27,4 +27,4 @@ def main(ctx, sketches_dir):
         ctx.obj.ERROR(f"Inconsistent sketches files.")
     
     ctx.obj.INFO(f"Indexing sketches in {sketches_dir}.")
-    kSpider_internal.index_datasets(sketches_dir)
+    kSpider_internal.datasets_indexing(sketches_dir)

--- a/pykSpider/kSpider2/ks_fastx_to_kfs.py
+++ b/pykSpider/kSpider2/ks_fastx_to_kfs.py
@@ -18,9 +18,10 @@ import os
 @click.option('--protein', "protein", is_flag=True, show_default=True, default=False, help="parsing protein")
 @click.option('--singletones', "singletones", is_flag=True, show_default=True, default=False, help="remove singletones")
 @click.option('--dayhoff', "dayhoff", is_flag=True, show_default=True, default=False, help="parsing protein in dayhoff encoding")
+@click.option('--ondisk', "ondisk", is_flag=True, show_default=True, default=False, help="on-disk sketch (reduced memory usage)")
 @click.option('-s', '--scale', "downsampling_ratio", required=False, default = 1, help="Downsampling ratio")
 @click.pass_context
-def main(ctx, fastx, r1, r2, chunk_size, kSize, protein, dayhoff, downsampling_ratio, singletones):
+def main(ctx, fastx, r1, r2, chunk_size, kSize, protein, dayhoff, downsampling_ratio, singletones, ondisk):
     """
     Sketch sequence files.
     """
@@ -53,16 +54,16 @@ def main(ctx, fastx, r1, r2, chunk_size, kSize, protein, dayhoff, downsampling_r
 
     if protein_flag:
         ctx.obj.INFO("Processing protein in default mode.")
-        kSpider_internal.protein_to_kDataFrame(fastx, kSize, chunk_size, False, os.path.basename(fastx), downsampling_ratio)
+        kSpider_internal.protein_to_kDataFrame(fastx, kSize, chunk_size, False, os.path.basename(fastx), downsampling_ratio, ondisk)
     elif dayhoff_flag:
         ctx.obj.INFO("Processing protein in dayhoff mode.")
-        kSpider_internal.protein_to_kDataFrame(fastx, kSize, chunk_size, True, os.path.basename(fastx), downsampling_ratio)
+        kSpider_internal.protein_to_kDataFrame(fastx, kSize, chunk_size, True, os.path.basename(fastx), downsampling_ratio, ondisk)
     elif single_end_flag:
         ctx.obj.INFO("Processing single-end reads.")
-        kSpider_internal.single_end_to_kDataFrame(fastx, kSize, chunk_size, downsampling_ratio, singletones)
+        kSpider_internal.single_end_to_kDataFrame(fastx, kSize, chunk_size, downsampling_ratio, singletones, ondisk)
     elif paired_end_flag:
         ctx.obj.INFO("Processing paired-end reads.")
-        kSpider_internal.paired_end_to_kDataFrame(r1, r2, kSize, chunk_size, downsampling_ratio, singletones)
+        kSpider_internal.paired_end_to_kDataFrame(r1, r2, kSize, chunk_size, downsampling_ratio, singletones, ondisk)
     else:
         ctx.obj.ERROR("Something went wrong!")
 

--- a/setup.py
+++ b/setup.py
@@ -95,12 +95,17 @@ INCLUDES = [
     'include',
     'lib/argh',
     'lib/kProcessor/include/kProcessor',
+    'lib/kProcessor/include/kProcessor/kDataframes',
     'lib/kProcessor/ThirdParty/MQF/include',
     'lib/kProcessor/ThirdParty/kmerDecoder/include',
     'lib/kProcessor/ThirdParty/kmerDecoder/lib/kseq/include',
     'lib/kProcessor/ThirdParty/sdsl-lite/include',
     'lib/kProcessor/ThirdParty/ntCard/include',
     'lib/kProcessor/ThirdParty/kmerDecoder/lib/parallel-hashmap',
+    'lib/kProcessor/ThirdParty/caches/include',
+    'lib/kProcessor/ThirdParty/KMC/kmc_api',
+    'lib/kProcessor/ThirdParty/mum-hash',
+    'lib/kProcessor/ThirdParty/Blight',
 ]
 
 check_exist(INCLUDES)
@@ -123,6 +128,7 @@ LIBRARIES_DIRS = [
     f"{kSpider_BUILD_DIR_dir}/lib/kProcessor/ThirdParty/sdsl-lite/lib",
     f"{kSpider_BUILD_DIR_dir}/lib/kProcessor/ThirdParty/kmerDecoder",
     f"{kSpider_BUILD_DIR_dir}/lib/kProcessor/ThirdParty/MQF/ThirdParty/stxxl/lib",
+    f"lib/kProcessor/ThirdParty/Blight",
 ]
 
 check_exist(LIBRARIES_DIRS)
@@ -135,6 +141,7 @@ LIBRARIES = [
     'ntcard',
     'kmerDecoder',
     'stxxl_debug',
+    'blight',
 ]
 
 SWIG_OPTS = [

--- a/src/fastx_to_kf.cpp
+++ b/src/fastx_to_kf.cpp
@@ -13,7 +13,7 @@
 
 namespace kSpider {
 
-    void paired_end_to_kDataFrame(string r1_file_name, string r2_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones) {
+    void paired_end_to_kDataFrame(string r1_file_name, string r2_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones, bool ondisk) {
 
         string PE_1_reads_file = r1_file_name;
         string PE_2_reads_file = r2_file_name;
@@ -93,16 +93,30 @@ namespace kSpider {
                 it++;
             }
             cout << "removed " << removed_singletones << " singletones." << endl;
-            new_kf->save(base_filename);
-            cout << "filename(" << base_filename << "): total(" << total_kmers << ") inserted(" << (inserted_kmers - removed_singletones) << ") << inserted_unique(" << new_kf->size() << ")" << endl;
+        // could be refactored later
+        kDataFrame* kf_mqf;
+        if(ondisk){
+            cout << "converting to on-disk sketch.." << endl;
+            kDataFrameFactory::createBMQF(new_kf, base_filename);
+        }else{
+            kf_mqf = kDataFrameFactory::createMQF(new_kf);
+            kf_mqf->save(base_filename);
         }
+        cout << "filename(" << base_filename << "): total(" << total_kmers << ") inserted(" << (inserted_kmers - removed_singletones) << ") << inserted_unique(" << new_kf->size() << ")" << endl;        }
         else {
-            kf->save(base_filename);
-            cout << "filename(" << base_filename << "): total(" << total_kmers << ") inserted(" << inserted_kmers << ") << inserted_unique(" << kf->size() << ")" << endl;
+            kDataFrame* kf_mqf;
+            if(ondisk){
+                cout << "converting to on-disk sketch.." << endl;
+                kDataFrameFactory::createBMQF(kf, base_filename);
+            }else{
+                kf_mqf = kDataFrameFactory::createMQF(kf);
+                kf_mqf->save(base_filename);
+            }
+        cout << "filename(" << base_filename << "): total(" << total_kmers << ") inserted(" << inserted_kmers << ") << inserted_unique(" << kf->size() << ")" << endl;
         }
     }
 
-    void single_end_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones) {
+    void single_end_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones, bool ondisk) {
 
     string PE_1_reads_file = r1_file_name;
 
@@ -160,17 +174,32 @@ namespace kSpider {
             it++;
         }
         cout << "removed " << removed_singletones << " singletones." << endl;
-        new_kf->save(base_filename);
+        // could be refactored later
+        kDataFrame* kf_mqf;
+        if(ondisk){
+            cout << "converting to on-disk sketch.." << endl;
+            kDataFrameFactory::createBMQF(new_kf, base_filename);
+        }else{
+            kf_mqf = kDataFrameFactory::createMQF(new_kf);
+            kf_mqf->save(base_filename);
+        }
         cout << "filename(" << base_filename << "): total(" << total_kmers << ") inserted(" << (inserted_kmers - removed_singletones) << ") << inserted_unique(" << new_kf->size() << ")" << endl;
     }
     else {
-        kf->save(base_filename);
+        kDataFrame* kf_mqf;
+        if(ondisk){
+            cout << "converting to on-disk sketch.." << endl;
+            kDataFrameFactory::createBMQF(kf, base_filename);
+        }else{
+            kf_mqf = kDataFrameFactory::createMQF(kf);
+            kf_mqf->save(base_filename);
+        }
         cout << "filename(" << base_filename << "): total(" << total_kmers << ") inserted(" << inserted_kmers << ") << inserted_unique(" << kf->size() << ")" << endl;
     }
 }
 
 
-    void protein_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, bool is_dayhoff, string output_prefix, int downsampling_ratio) {
+    void protein_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, bool is_dayhoff, string output_prefix, int downsampling_ratio, bool ondisk) {
 
         string PE_1_reads_file = r1_file_name;
 
@@ -216,8 +245,15 @@ namespace kSpider {
             }
         }
 
+        kDataFrame* kf_mqf;
+        if(ondisk){
+            cout << "converting to on-disk sketch.." << endl;
+            kDataFrameFactory::createBMQF(kf, output_prefix);
+        }else{
+            kf_mqf = kDataFrameFactory::createMQF(kf);
+            kf_mqf->save(output_prefix);
+        }
         cout << "filename(" << output_prefix << "): total(" << total_kmers << ") inserted(" << inserted_kmers << ")" << endl;
-        kf->save(output_prefix);
     }
 
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2,15 +2,15 @@
 #include <iostream>
 #include <cstdint>
 #include <chrono>
-#include "colored_kDataFrame.hpp"
 #include "parallel_hashmap/phmap.h"
-#include "kDataFrame.hpp"
 #include "algorithms.hpp"
 #include <glob.h> // glob(), globfree()
 #include <vector>
 #include <stdexcept>
 #include <sstream>
 #include <string.h>
+#include "defaultColumn.hpp"
+#include "kDataframes/kDataFrameSTL.hpp"
 
 #define LOWEST_PERCENTILE 5
 
@@ -25,7 +25,7 @@ std::vector<std::string> glob(const std::string& pattern) {
 
     // do the glob operation
     int return_value = glob(pattern.c_str(), GLOB_TILDE, NULL, &glob_result);
-    if(return_value != 0) {
+    if (return_value != 0) {
         globfree(&glob_result);
         stringstream ss;
         ss << "glob() failed with return_value " << return_value << endl;
@@ -34,7 +34,7 @@ std::vector<std::string> glob(const std::string& pattern) {
 
     // collect all the filenames into a std::list<std::string>
     vector<string> filenames;
-    for(size_t i = 0; i < glob_result.gl_pathc; ++i) {
+    for (size_t i = 0; i < glob_result.gl_pathc; ++i) {
         filenames.push_back(string(glob_result.gl_pathv[i]));
     }
 
@@ -49,214 +49,44 @@ std::vector<std::string> glob(const std::string& pattern) {
 namespace kSpider {
 
     void index_kmers(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix) {
-        auto* KF = new kDataFrameMQF(KMERS, integer_hasher, { {"kSize", kSize} });
-        auto* ckf = kProcessor::index(KF, fasta_file, chunk_size, names_file);
-        ckf->save(index_prefix);
+        auto* KF = new kDataFramePHMAP(KMERS, integer_hasher, { {"kSize", kSize} });
+        kmerDecoder* KD = kmerDecoder::getInstance(fasta_file, chunk_size, KMERS, integer_hasher, { {"kSize", kSize} });
+        kProcessor::index(KD, names_file, KF);
+        KF->save(index_prefix);
     }
 
     void index_kmers_nonCanonical(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix) {
-        auto* KF = new kDataFrameMQF(KMERS, nonCanonicalInteger_Hasher, { {"kSize", kSize} });
-        auto* ckf = kProcessor::index(KF, fasta_file, chunk_size, names_file);
-        ckf->save(index_prefix);
+        auto* KF = new kDataFramePHMAP(KMERS, nonCanonicalInteger_Hasher, { {"kSize", kSize} });
+        kmerDecoder* KD = kmerDecoder::getInstance(fasta_file, chunk_size, KMERS, nonCanonicalInteger_Hasher, { {"kSize", kSize} });
+        kProcessor::index(KD, names_file, KF);
+        KF->save(index_prefix);
     }
 
     void index_skipmers(int m, int n, int k, string fasta_file, string names_file, int chunk_size, string index_prefix) {
-        auto* KF = new kDataFramePHMAP(SKIPMERS, integer_hasher, { {"m", m}, {"n", n}, {"k", k} });
-        auto* ckf = kProcessor::index(KF, fasta_file, chunk_size, names_file);
-        ckf->save(index_prefix);
+
+        auto* KF = new kDataFramePHMAP(KMERS, integer_hasher, { {"m", m}, {"n", n}, {"k", k} });
+        kmerDecoder* KD = kmerDecoder::getInstance(fasta_file, chunk_size, SKIPMERS, integer_hasher, { {"m", m}, {"n", n}, {"k", k} });
+        kProcessor::index(KD, names_file, KF);
+        KF->save(index_prefix);
     }
 
     void index_protein(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix) {
         auto* KF = new kDataFramePHMAP(PROTEIN, protein_hasher, { {"kSize", kSize} });
-        auto* ckf = kProcessor::index(KF, fasta_file, chunk_size, names_file);
-        ckf->save(index_prefix);
+        kmerDecoder* KD = kmerDecoder::getInstance(fasta_file, chunk_size, PROTEIN, protein_hasher, { {"kSize", kSize} });
+        kProcessor::index(KD, names_file, KF);
+        KF->save(index_prefix);
     }
 
     void index_dayhoff(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix) {
         auto* KF = new kDataFramePHMAP(PROTEIN, proteinDayhoff_hasher, { {"kSize", kSize} });
-        auto* ckf = kProcessor::index(KF, fasta_file, chunk_size, names_file);
-        ckf->save(index_prefix);
+        kmerDecoder* KD = kmerDecoder::getInstance(fasta_file, chunk_size, PROTEIN, proteinDayhoff_hasher, { {"kSize", kSize} });
+        kProcessor::index(KD, names_file, KF);
+        KF->save(index_prefix);
     }
-
-    void index(kmerDecoder *KD, string names_fileName, kDataFrame *frame) {
-        if (KD->get_kSize() != (int) frame->ksize()) {
-            std::cerr << "kmerDecoder kSize must be equal to kDataFrame kSize" << std::endl;
-            exit(1);
-        }
-
-
-        auto *colors =new deduplicatedColumn< StringColorColumn>();
-        frame->addColumn("color",(Column *) colors);
-        flat_hash_map<string, string> namesMap;
-        flat_hash_map<string, uint64_t> tagsMap;
-        flat_hash_map<string, uint64_t> groupNameMap;
-        auto *legend = new flat_hash_map<uint64_t, std::vector<uint32_t>>();
-        flat_hash_map<uint64_t, uint64_t> colorsCount;
-        uint64_t readID = 0, groupID = 1;
-        ifstream namesFile(names_fileName.c_str());
-        string seqName, groupName;
-        string line;
-        priority_queue<uint64_t, vector<uint64_t>, std::greater<uint64_t>> freeColors;
-        flat_hash_map<string, uint64_t> groupCounter;
-//        while (namesFile >> seqName >> groupName) {
-        while (std::getline(namesFile, line)) {
-            std::vector<string> tokens;
-            std::istringstream iss(line);
-            std::string token;
-            while (std::getline(iss, token, '\t'))   // but we can specify a different one
-                tokens.push_back(token);
-            seqName = tokens[0];
-            groupName = tokens[1];
-            namesMap.insert(make_pair(seqName, groupName));
-            auto it = groupNameMap.find(groupName);
-            groupCounter[groupName]++;
-            if (it == groupNameMap.end()) {
-                groupNameMap.insert(make_pair(groupName, groupID));
-                tagsMap.insert(make_pair(to_string(groupID), groupID));
-                vector<uint32_t> tmp;
-                tmp.clear();
-                tmp.push_back(groupID);
-                legend->insert(make_pair(groupID, tmp));
-                colorsCount.insert(make_pair(groupID, 0));
-                groupID++;
-            }
-        }
-
-
-        flat_hash_map<uint64_t, string> inv_groupNameMap;
-            for (auto &_ : groupNameMap)
-                inv_groupNameMap[_.second] = _.first;
-
-//        int currIndex = 0;
-        string kmer;
-//        uint64_t tagBits = 0;
-//        uint64_t maxTagValue = (1ULL << tagBits) - 1;
-        //  kDataFrame *frame;
-//        int kSize = KD->get_kSize();
-
-
-//        uint64_t lastTag = 0;
-        readID = 0;
-
-        while (!KD->end()) {
-            KD->next_chunk();
-
-            flat_hash_map<uint64_t, uint64_t> convertMap;
-
-            for (const auto &seq : *KD->getKmers()) {
-                string readName = seq.first;
-
-                auto it = namesMap.find(readName);
-                if (it == namesMap.end()) {
-                    cerr << "WARNING: " << "read " << readName << "doesn't have a group. Please, check the names file." << endl;
-                    continue;
-                }
-                string groupName = it->second;
-
-                uint64_t readTag = groupNameMap.find(groupName)->second;
-
-
-                convertMap.clear();
-                convertMap.insert(make_pair(0, readTag));
-                convertMap.insert(make_pair(readTag, readTag));
-                //    cout<<readName<<"   "<<seq.size()<<endl;
-                for (const auto &kmer : seq.second) {
-                    frame->insert(kmer.hash);
-                    uint64_t kmerOrder =frame->getkmerOrder(kmer.hash);
-                    if(colors->size()<frame->size()+1)
-                        colors->resize(frame->size()+1);
-                    uint64_t currentTag = colors->index[kmerOrder];
-                    auto itc = convertMap.find(currentTag);
-                    if (itc == convertMap.end()) {
-                        vector<uint32_t> colors = legend->find(currentTag)->second;
-                        auto tmpiT = find(colors.begin(), colors.end(), readTag);
-                        if (tmpiT == colors.end()) {
-                            colors.push_back(readTag);
-                            sort(colors.begin(), colors.end());
-                        }
-
-                        string colorsString = to_string(colors[0]);
-                        for (unsigned int k = 1; k < colors.size(); k++) {
-                            colorsString += ";" + to_string(colors[k]);
-                        }
-
-                        auto itTag = tagsMap.find(colorsString);
-                        if (itTag == tagsMap.end()) {
-                            uint64_t newColor;
-                            if (freeColors.empty()) {
-                                newColor = groupID++;
-                            } else {
-                                newColor = freeColors.top();
-                                freeColors.pop();
-                            }
-
-                            tagsMap.insert(make_pair(colorsString, newColor));
-                            legend->insert(make_pair(newColor, colors));
-                            itTag = tagsMap.find(colorsString);
-                            colorsCount[newColor] = 0;
-                            // if(groupID>=maxTagValue){
-                            //   cerr<<"Tag size is not enough. ids reached "<<groupID<<endl;
-                            //   return -1;
-                            // }
-                        }
-                        uint64_t newColor = itTag->second;
-
-                        convertMap.insert(make_pair(currentTag, newColor));
-                        itc = convertMap.find(currentTag);
-                    }
-
-                    if (itc->second != currentTag) {
-
-                        colorsCount[currentTag]--;
-                        if (colorsCount[currentTag] == 0 && currentTag != 0) {
-                            auto _invGroupNameIT = inv_groupNameMap.find(currentTag);
-                            if (_invGroupNameIT == inv_groupNameMap.end()){
-                                freeColors.push(currentTag);
-
-                                vector<uint32_t> colors = legend->find(currentTag)->second;
-                                string colorsString = to_string(colors[0]);
-                                for (unsigned int k = 1; k < colors.size(); k++) {
-                                    colorsString += ";" + to_string(colors[k]);
-                                }
-                                tagsMap.erase(colorsString);
-                                
-                                legend->erase(currentTag);
-                                if (convertMap.find(currentTag) != convertMap.end())
-                                    convertMap.erase(currentTag);
-                            }
-
-                        }
-                        colorsCount[itc->second]++;
-                    }
-
-                    colors->index[kmerOrder]=itc->second;
-
-                }
-                readID += 1;
-                groupCounter[groupName]--;
-                if (colorsCount[readTag] == 0) {                   
-                    if (groupCounter[groupName] == 0) {
-                        freeColors.push(readTag);
-                        legend->erase(readTag);
-                    }
-                }
-            }
-        }
-
-        colors->values = new StringColorColumn(legend,groupCounter.size());
-        delete legend;
-        for (auto & iit : namesMap) {
-            uint32_t sampleID = groupNameMap[iit.second];
-            colors->values->namesMap[sampleID] = iit.second;
-        }
-
-    }
-
 
     void index_datasets(string kfs_dir) {
 
-
-        kDataFrame * frame;
+        kDataFrame* frame;
         std::string dir_prefix = kfs_dir.substr(kfs_dir.find_last_of("/\\") + 1);
 
         flat_hash_map<string, string> namesMap;
@@ -264,7 +94,7 @@ namespace kSpider {
 
         flat_hash_map<string, uint64_t> tagsMap;
         flat_hash_map<string, uint64_t> groupNameMap;
-        flat_hash_map<uint64_t, std::vector<uint32_t>> *legend = new flat_hash_map<uint64_t, std::vector<uint32_t>>();
+        auto* legend = new flat_hash_map<uint64_t, std::vector<uint32_t>>();
         flat_hash_map<uint64_t, uint64_t> colorsCount;
         uint64_t readID = 0, groupID = 1;
         string seqName, groupName;
@@ -275,41 +105,46 @@ namespace kSpider {
         int total_kfs_number = 0;
 
         // get kSize and type
-         for (const auto& dirEntry : glob(kfs_dir + "/*")) {
+        for (const auto& dirEntry : glob(kfs_dir + "/*")) {
             string file_name = (string)dirEntry;
             size_t lastindex = file_name.find_last_of(".");
             string kf_prefix = file_name.substr(0, lastindex);
             std::string::size_type idx;
             idx = file_name.rfind('.');
             std::string extension = "";
-            if(idx != std::string::npos) extension = file_name.substr(idx+1);
+            if (idx != std::string::npos) extension = file_name.substr(idx + 1);
             int detected_kSize;
             hashingModes _hm;
-            if(extension == "mqf" || extension == "phmap") {
-                auto * _kf = kDataFrame::load(kf_prefix);
+            if (extension == "mqf" || extension == "phmap") {
+                auto* _kf = kDataFrame::load(kf_prefix);
                 _hm = _kf->getkmerDecoder()->hash_mode;
                 detected_kSize = _kf->getkSize();
                 cout << "Detected kSize: " << detected_kSize << endl;
-            }else{
+            }
+            else {
                 continue;
             }
             // if(extension == "mqf") {frame = new kDataFrameMQF(detected_kSize, 30, mumur_hasher); break;} // temp. switch off
-            if(extension == "mqf") {frame = new kDataFramePHMAP(detected_kSize, _hm); break;}
-            else if(extension == "phmap") {frame = new kDataFramePHMAP(detected_kSize, _hm); break;}
-            else {continue;}
+            if (extension == "mqf") { frame = new kDataFramePHMAP(detected_kSize, _hm); break; }
+            else if (extension == "phmap") { frame = new kDataFramePHMAP(detected_kSize, _hm); break; }
+            else { continue; }
         }
+
+
+        auto* colors = new deduplicatedColumn< StringColorColumn>();
+        frame->addColumn("color", (Column*)colors);
 
         for (const auto& dirEntry : glob(kfs_dir + "/*")) {
             string file_name = (string)dirEntry;
             size_t lastindex = file_name.find_last_of(".");
             string kf_prefix = file_name.substr(0, lastindex);
 
-            
+
             std::string::size_type idx;
             idx = file_name.rfind('.');
             std::string extension = "";
-            if(idx != std::string::npos) extension = file_name.substr(idx+1);
-            if(extension != "mqf" and extension != "phmap") continue;
+            if (idx != std::string::npos) extension = file_name.substr(idx + 1);
+            if (extension != "mqf" and extension != "phmap") continue;
 
             total_kfs_number++;
 
@@ -329,31 +164,17 @@ namespace kSpider {
                 legend->insert(make_pair(groupID, tmp));
                 colorsCount.insert(make_pair(groupID, 0));
                 groupID++;
-
             }
         }
-
-        cout << "namesmap construction done..." << endl;
-
-
-        // ----------------------------------------------------------------
 
 
         flat_hash_map<uint64_t, string> inv_groupNameMap;
         for (auto& _ : groupNameMap)
             inv_groupNameMap[_.second] = _.first;
 
-
-        int currIndex = 0;
         string kmer;
-        uint64_t tagBits = 0;
-        uint64_t maxTagValue = (1ULL << tagBits) - 1;
-        //  kDataFrame *frame;
-
-        uint64_t lastTag = 0;
-        readID = 0;
         int __batch_count = 0;
-
+        readID = 0;
         int processed_kfs_count = 0;
 
         for (const auto& dirEntry : glob(kfs_dir + "/*")) {
@@ -362,130 +183,100 @@ namespace kSpider {
             string kf_prefix = file_name.substr(0, lastindex);
 
             std::string kf_basename = kf_prefix.substr(kf_prefix.find_last_of("/\\") + 1);
-            
-            
+
+
             std::string::size_type idx;
             idx = file_name.rfind('.');
             std::string extension = "";
-            if(idx != std::string::npos) extension = file_name.substr(idx+1);
-            if(extension != "mqf" and extension != "phmap") continue;
-            
-            // uint64_t removed_kmers_from_percentile = 0;
-            auto * loaded_kf = kDataFrame::load(kf_prefix);
+            if (idx != std::string::npos) extension = file_name.substr(idx + 1);
+            if (extension != "mqf" and extension != "phmap") continue;
+
+            auto* loaded_kf = kDataFrame::load(kf_prefix);
             cout << "Processing " << ++processed_kfs_count << "/" << total_kfs_number << " | " << kf_basename << " k:" << loaded_kf->ksize() << " ... " << endl;
 
-            // Calculating percentile
-            // auto perc_kf_it = loaded_kf->begin();
-            // auto* kmerCounts = new(vector<uint64_t>);
-            // uint64_t real_no_of_kmers = 0;
-            // while (perc_kf_it != loaded_kf->end()) {
-            //     kmerCounts->push_back(perc_kf_it.getCount());
-            //     real_no_of_kmers++;
-            //     perc_kf_it++;
-            // }
-            // sort(kmerCounts->begin(), kmerCounts->end());
-            // uint64_t _idx = (uint64_t)ceil((real_no_of_kmers * LOWEST_PERCENTILE / 100));
-            // uint64_t count_percentile_cutoff = kmerCounts->at(_idx);
-            // cout << "   calculated percentile cutoff kmercount=" << count_percentile_cutoff << endl;
-            // delete kmerCounts;
 
             flat_hash_map<uint64_t, uint64_t> convertMap;
             string readName = kf_basename;
             auto loaded_kf_it = loaded_kf->begin();
+            string groupName = kf_basename;
+            uint64_t readTag = groupNameMap.find(groupName)->second;
+            convertMap.clear();
+            convertMap.insert(make_pair(0, readTag));
+            convertMap.insert(make_pair(readTag, readTag));
 
+            while (loaded_kf_it != loaded_kf->end()) {
                 string groupName = kf_basename;
+                uint64_t hashed_kmer = loaded_kf_it.getHashedKmer();
 
-                uint64_t readTag = groupNameMap.find(groupName)->second;
+                frame->insert(hashed_kmer);
 
-
-                convertMap.clear();
-                convertMap.insert(make_pair(0, readTag));
-                convertMap.insert(make_pair(readTag, readTag));
-
-               while (loaded_kf_it != loaded_kf->end()) {
-                    
-                    // Don't consider the kmer if it exist in the lower percentile
-                    // if(loaded_kf_it.getCount() < count_percentile_cutoff){
-                    //     removed_kmers_from_percentile++;
-                    //     loaded_kf_it++;
-                    //     continue; 
-                    // }
-
-                    uint64_t hashed_kmer = loaded_kf_it.getHashedKmer();
-                    uint64_t currentTag = frame->getCount(hashed_kmer);
-                    auto itc = convertMap.find(currentTag);
-                    if (itc == convertMap.end()) {
-                        vector<uint32_t> colors = legend->find(currentTag)->second;
-                        auto tmpiT = find(colors.begin(), colors.end(), readTag);
-                        if (tmpiT == colors.end()) {
-                            colors.push_back(readTag);
-                            sort(colors.begin(), colors.end());
-                        }
-
-                        string colorsString = to_string(colors[0]);
-                        for (int k = 1; k < colors.size(); k++) {
-                            colorsString += ";" + to_string(colors[k]);
-                        }
-
-                        auto itTag = tagsMap.find(colorsString);
-                        if (itTag == tagsMap.end()) {
-                            uint64_t newColor;
-                            if (freeColors.size() == 0) {
-                                newColor = groupID++;
-                            }
-                            else {
-                                newColor = freeColors.top();
-                                freeColors.pop();
-                            }
-
-                            tagsMap.insert(make_pair(colorsString, newColor));
-                            legend->insert(make_pair(newColor, colors));
-                            itTag = tagsMap.find(colorsString);
-                            colorsCount[newColor] = 0;
-                            // if(groupID>=maxTagValue){
-                            //   cerr<<"Tag size is not enough. ids reached "<<groupID<<endl;
-                            //   return -1;
-                            // }
-                        }
-                        uint64_t newColor = itTag->second;
-
-                        convertMap.insert(make_pair(currentTag, newColor));
-                        itc = convertMap.find(currentTag);
+                uint64_t kmerOrder = frame->getkmerOrder(hashed_kmer);
+                if (colors->size() < frame->size() + 1)
+                    colors->resize(frame->size() + 1);
+                uint64_t currentTag = colors->index[kmerOrder];
+                auto itc = convertMap.find(currentTag);
+                if (itc == convertMap.end()) {
+                    vector<uint32_t> colors = legend->find(currentTag)->second;
+                    auto tmpiT = find(colors.begin(), colors.end(), readTag);
+                    if (tmpiT == colors.end()) {
+                        colors.push_back(readTag);
+                        sort(colors.begin(), colors.end());
                     }
 
-                    if (itc->second != currentTag) {
+                    string colorsString = to_string(colors[0]);
+                    for (unsigned int k = 1; k < colors.size(); k++) {
+                        colorsString += ";" + to_string(colors[k]);
+                    }
 
-                        colorsCount[currentTag]--;
-                        if (colorsCount[currentTag] == 0 && currentTag != 0) {
-
-                            auto _invGroupNameIT = inv_groupNameMap.find(currentTag);
-                            if (_invGroupNameIT == inv_groupNameMap.end()) {
-                                freeColors.push(currentTag);
-                                vector<uint32_t> colors = legend->find(currentTag)->second;
-                                string colorsString = to_string(colors[0]);
-                                for (unsigned int k = 1; k < colors.size(); k++) {
-                                    colorsString += ";" + to_string(colors[k]);
-                                }
-                                tagsMap.erase(colorsString);
-                                legend->erase(currentTag);
-                                if (convertMap.find(currentTag) != convertMap.end())
-                                    convertMap.erase(currentTag);
-                            }
-
+                    auto itTag = tagsMap.find(colorsString);
+                    if (itTag == tagsMap.end()) {
+                        uint64_t newColor;
+                        if (freeColors.empty()) {
+                            newColor = groupID++;
                         }
-                        colorsCount[itc->second]++;
-                    }
+                        else {
+                            newColor = freeColors.top();
+                            freeColors.pop();
+                        }
 
-                    frame->setCount(hashed_kmer, itc->second);
-                    if (frame->getCount(hashed_kmer) != itc->second) {
-                        //frame->setC(kmer,itc->second);
-                        cout << "Error Founded " << hashed_kmer << " from sequence " << readName << " expected "
-                            << itc->second << " found " << frame->getCount(hashed_kmer) << endl;
-                        exit(1);
+                        tagsMap.insert(make_pair(colorsString, newColor));
+                        legend->insert(make_pair(newColor, colors));
+                        itTag = tagsMap.find(colorsString);
+                        colorsCount[newColor] = 0;
                     }
-                    loaded_kf_it++;
+                    uint64_t newColor = itTag->second;
+
+                    convertMap.insert(make_pair(currentTag, newColor));
+                    itc = convertMap.find(currentTag);
                 }
-                // cout << "   Removed kmers from percentile=(" << removed_kmers_from_percentile <<") out of ("<< real_no_of_kmers <<")" << endl;
+
+                if (itc->second != currentTag) {
+
+                    colorsCount[currentTag]--;
+                    if (colorsCount[currentTag] == 0 && currentTag != 0) {
+                        auto _invGroupNameIT = inv_groupNameMap.find(currentTag);
+                        if (_invGroupNameIT == inv_groupNameMap.end()) {
+                            freeColors.push(currentTag);
+
+                            vector<uint32_t> colors = legend->find(currentTag)->second;
+                            string colorsString = to_string(colors[0]);
+                            for (unsigned int k = 1; k < colors.size(); k++) {
+                                colorsString += ";" + to_string(colors[k]);
+                            }
+                            tagsMap.erase(colorsString);
+
+                            legend->erase(currentTag);
+                            if (convertMap.find(currentTag) != convertMap.end())
+                                convertMap.erase(currentTag);
+                        }
+
+                    }
+                    colorsCount[itc->second]++;
+                }
+
+                colors->index[kmerOrder] = itc->second;
+
+
                 readID += 1;
                 groupCounter[groupName]--;
                 if (colorsCount[readTag] == 0) {
@@ -493,28 +284,20 @@ namespace kSpider {
                         freeColors.push(readTag);
                         legend->erase(readTag);
                     }
-                    
                 }
-                cout << "   saved_kmers(~" << frame->size() << ")." << endl << endl;
-                delete loaded_kf;
+                loaded_kf_it++;
+            }
         }
 
-
-        colorTable* colors = new intVectorsTable();
-        for (auto it : *legend) {
-            colors->setColor(it.first, it.second);
+        colors->values = new StringColorColumn(legend, groupCounter.size());
+        delete legend;
+        for (auto& iit : namesMap) {
+            uint32_t sampleID = groupNameMap[iit.second];
+            colors->values->namesMap[sampleID] = iit.second;
         }
 
-        colored_kDataFrame* res = new colored_kDataFrame();
-        res->setColorTable(colors);
-        res->setkDataFrame(frame);
-        for (auto iit = namesMap.begin(); iit != namesMap.end(); iit++) {
-            uint32_t sampleID = groupNameMap[iit->second];
-            res->namesMap[sampleID] = iit->second;
-            res->namesMapInv[iit->second] = sampleID;
-        }
-        cout << "saving to "<< dir_prefix << " ..." << endl;
-        res->save(dir_prefix);
+        cout << "saving to " << dir_prefix << " ..." << endl;
+        frame->save(dir_prefix);
+
     }
-
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -78,6 +78,180 @@ namespace kSpider {
         ckf->save(index_prefix);
     }
 
+    void index(kmerDecoder *KD, string names_fileName, kDataFrame *frame) {
+        if (KD->get_kSize() != (int) frame->ksize()) {
+            std::cerr << "kmerDecoder kSize must be equal to kDataFrame kSize" << std::endl;
+            exit(1);
+        }
+
+
+        auto *colors =new deduplicatedColumn< StringColorColumn>();
+        frame->addColumn("color",(Column *) colors);
+        flat_hash_map<string, string> namesMap;
+        flat_hash_map<string, uint64_t> tagsMap;
+        flat_hash_map<string, uint64_t> groupNameMap;
+        auto *legend = new flat_hash_map<uint64_t, std::vector<uint32_t>>();
+        flat_hash_map<uint64_t, uint64_t> colorsCount;
+        uint64_t readID = 0, groupID = 1;
+        ifstream namesFile(names_fileName.c_str());
+        string seqName, groupName;
+        string line;
+        priority_queue<uint64_t, vector<uint64_t>, std::greater<uint64_t>> freeColors;
+        flat_hash_map<string, uint64_t> groupCounter;
+//        while (namesFile >> seqName >> groupName) {
+        while (std::getline(namesFile, line)) {
+            std::vector<string> tokens;
+            std::istringstream iss(line);
+            std::string token;
+            while (std::getline(iss, token, '\t'))   // but we can specify a different one
+                tokens.push_back(token);
+            seqName = tokens[0];
+            groupName = tokens[1];
+            namesMap.insert(make_pair(seqName, groupName));
+            auto it = groupNameMap.find(groupName);
+            groupCounter[groupName]++;
+            if (it == groupNameMap.end()) {
+                groupNameMap.insert(make_pair(groupName, groupID));
+                tagsMap.insert(make_pair(to_string(groupID), groupID));
+                vector<uint32_t> tmp;
+                tmp.clear();
+                tmp.push_back(groupID);
+                legend->insert(make_pair(groupID, tmp));
+                colorsCount.insert(make_pair(groupID, 0));
+                groupID++;
+            }
+        }
+
+
+        flat_hash_map<uint64_t, string> inv_groupNameMap;
+            for (auto &_ : groupNameMap)
+                inv_groupNameMap[_.second] = _.first;
+
+//        int currIndex = 0;
+        string kmer;
+//        uint64_t tagBits = 0;
+//        uint64_t maxTagValue = (1ULL << tagBits) - 1;
+        //  kDataFrame *frame;
+//        int kSize = KD->get_kSize();
+
+
+//        uint64_t lastTag = 0;
+        readID = 0;
+
+        while (!KD->end()) {
+            KD->next_chunk();
+
+            flat_hash_map<uint64_t, uint64_t> convertMap;
+
+            for (const auto &seq : *KD->getKmers()) {
+                string readName = seq.first;
+
+                auto it = namesMap.find(readName);
+                if (it == namesMap.end()) {
+                    cerr << "WARNING: " << "read " << readName << "doesn't have a group. Please, check the names file." << endl;
+                    continue;
+                }
+                string groupName = it->second;
+
+                uint64_t readTag = groupNameMap.find(groupName)->second;
+
+
+                convertMap.clear();
+                convertMap.insert(make_pair(0, readTag));
+                convertMap.insert(make_pair(readTag, readTag));
+                //    cout<<readName<<"   "<<seq.size()<<endl;
+                for (const auto &kmer : seq.second) {
+                    frame->insert(kmer.hash);
+                    uint64_t kmerOrder =frame->getkmerOrder(kmer.hash);
+                    if(colors->size()<frame->size()+1)
+                        colors->resize(frame->size()+1);
+                    uint64_t currentTag = colors->index[kmerOrder];
+                    auto itc = convertMap.find(currentTag);
+                    if (itc == convertMap.end()) {
+                        vector<uint32_t> colors = legend->find(currentTag)->second;
+                        auto tmpiT = find(colors.begin(), colors.end(), readTag);
+                        if (tmpiT == colors.end()) {
+                            colors.push_back(readTag);
+                            sort(colors.begin(), colors.end());
+                        }
+
+                        string colorsString = to_string(colors[0]);
+                        for (unsigned int k = 1; k < colors.size(); k++) {
+                            colorsString += ";" + to_string(colors[k]);
+                        }
+
+                        auto itTag = tagsMap.find(colorsString);
+                        if (itTag == tagsMap.end()) {
+                            uint64_t newColor;
+                            if (freeColors.empty()) {
+                                newColor = groupID++;
+                            } else {
+                                newColor = freeColors.top();
+                                freeColors.pop();
+                            }
+
+                            tagsMap.insert(make_pair(colorsString, newColor));
+                            legend->insert(make_pair(newColor, colors));
+                            itTag = tagsMap.find(colorsString);
+                            colorsCount[newColor] = 0;
+                            // if(groupID>=maxTagValue){
+                            //   cerr<<"Tag size is not enough. ids reached "<<groupID<<endl;
+                            //   return -1;
+                            // }
+                        }
+                        uint64_t newColor = itTag->second;
+
+                        convertMap.insert(make_pair(currentTag, newColor));
+                        itc = convertMap.find(currentTag);
+                    }
+
+                    if (itc->second != currentTag) {
+
+                        colorsCount[currentTag]--;
+                        if (colorsCount[currentTag] == 0 && currentTag != 0) {
+                            auto _invGroupNameIT = inv_groupNameMap.find(currentTag);
+                            if (_invGroupNameIT == inv_groupNameMap.end()){
+                                freeColors.push(currentTag);
+
+                                vector<uint32_t> colors = legend->find(currentTag)->second;
+                                string colorsString = to_string(colors[0]);
+                                for (unsigned int k = 1; k < colors.size(); k++) {
+                                    colorsString += ";" + to_string(colors[k]);
+                                }
+                                tagsMap.erase(colorsString);
+                                
+                                legend->erase(currentTag);
+                                if (convertMap.find(currentTag) != convertMap.end())
+                                    convertMap.erase(currentTag);
+                            }
+
+                        }
+                        colorsCount[itc->second]++;
+                    }
+
+                    colors->index[kmerOrder]=itc->second;
+
+                }
+                readID += 1;
+                groupCounter[groupName]--;
+                if (colorsCount[readTag] == 0) {                   
+                    if (groupCounter[groupName] == 0) {
+                        freeColors.push(readTag);
+                        legend->erase(readTag);
+                    }
+                }
+            }
+        }
+
+        colors->values = new StringColorColumn(legend,groupCounter.size());
+        delete legend;
+        for (auto & iit : namesMap) {
+            uint32_t sampleID = groupNameMap[iit.second];
+            colors->values->namesMap[sampleID] = iit.second;
+        }
+
+    }
+
 
     void index_datasets(string kfs_dir) {
 

--- a/src/pairwise.cpp
+++ b/src/pairwise.cpp
@@ -56,17 +56,24 @@ namespace kSpider {
         flat_hash_map<uint32_t, uint32_t> colorsCount;
 
         auto* kf = kDataFrame::load(index_prefix);
-        auto* colorColumn = (deduplicatedColumn<StringColorColumn>*) kf->columns["color"];
+        
+        // old_indexing
+        // auto* colorColumn = (deduplicatedColumn<StringColorColumn>*) kf->columns["color"];
 
-        uint32_t max_color_id = *max_element(colorColumn->index.begin(), colorColumn->index.end());
-        auto color_to_ids = flat_hash_map<uint64_t, std::vector<uint32_t>>(max_color_id);
+        // priorityQueue
+        auto * colorColumn = (deduplicatedColumn<mixVectors>*) kf->columns["color"];
 
+
+        flat_hash_map<uint64_t, std::vector<uint32_t>> color_to_ids;
 
         auto kf_it = kf->begin();
         while (kf_it != kf->end()) {
             uint32_t color_id = colorColumn->index[kf_it.getOrder()];
             colorsCount[color_id]++;
-            vector<uint32_t> group_ids = colorColumn->values->colors->get(color_id);
+            // old indexing
+            // vector<uint32_t> group_ids = colorColumn->values->colors->get(color_id);
+            vector<uint32_t> group_ids = kf->getKmerColumnValue<deduplicatedColumn<mixVectors> >("color", kf_it.getKmer());
+
             color_to_ids[color_id] = std::vector<uint32_t>();
             for (auto& grp_id : group_ids) {
                 if (grp_id >= 0) {

--- a/src/pairwise.cpp
+++ b/src/pairwise.cpp
@@ -1,12 +1,13 @@
 #include <iostream>
 #include <cstdint>
 #include <chrono>
-#include "colored_kDataFrame.hpp"
 #include "parallel_hashmap/phmap.h"
 #include "kDataFrame.hpp"
+#include "kDataframes/kDataFrameSTL.hpp"
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/functional/hash.hpp>
+#include<algorithm>
 
 using boost::adaptors::transformed;
 using boost::algorithm::join;
@@ -28,10 +29,10 @@ public:
     }
 
 private:
-    int *arr = new int[2];
+    int* arr = new int[2];
     int r = 2;
 
-    void comb(int n, int r, int *arr) {
+    void comb(int n, int r, int* arr) {
         for (int i = n; i >= r; i--) {
             // choose the first element
             arr[r - 1] = i;
@@ -39,7 +40,8 @@ private:
                 // recursive into smaller problem
                 comb(i - 1, r - 1, arr);
 
-            } else {
+            }
+            else {
                 this->combs.emplace_back(std::make_pair(arr[0] - 1, arr[1] - 1));
             }
         }
@@ -47,84 +49,84 @@ private:
 
 };
 
-namespace kSpider{
-void pairwise(string index_prefix) {
+namespace kSpider {
+    void pairwise(string index_prefix) {
 
-    // Read colors
-    string colors_map = index_prefix + "colors.intvectors";
-    ifstream input(colors_map.c_str());
-    int size;
-    input >> size;
-    flat_hash_map<uint64_t, vector<uint32_t>> color_to_ids = flat_hash_map<uint64_t, std::vector<uint32_t>>(size);
-    for (int i = 0; i < size; i++) {
-        uint64_t color, colorSize;
-        input >> color >> colorSize;
-        uint32_t sampleID;
-        color_to_ids[color] = std::vector<uint32_t>(colorSize);
-        for (int j = 0; j < colorSize; j++) {
-            input >> sampleID;
-            color_to_ids[color][j] = sampleID;
+        // Read colors
+        flat_hash_map<uint32_t, uint32_t> colorsCount;
+
+        auto* kf = kDataFrame::load(index_prefix);
+        auto* colorColumn = (deduplicatedColumn<StringColorColumn>*) kf->columns["color"];
+
+        uint32_t max_color_id = *max_element(colorColumn->index.begin(), colorColumn->index.end());
+        auto color_to_ids = flat_hash_map<uint64_t, std::vector<uint32_t>>(max_color_id);
+
+
+        auto kf_it = kf->begin();
+        while (kf_it != kf->end()) {
+            uint32_t color_id = colorColumn->index[kf_it.getOrder()];
+            colorsCount[color_id]++;
+            vector<uint32_t> group_ids = colorColumn->values->colors->get(color_id);
+            color_to_ids[color_id] = std::vector<uint32_t>();
+            for (auto& grp_id : group_ids) {
+                if (grp_id >= 0) {
+                    color_to_ids[color_id].emplace_back(grp_id);
+                }
+            }
+            kf_it++;
         }
-    }
 
-    flat_hash_map<uint32_t, uint32_t> colorsCount;
+        // Free some memory
+        cout << "[INFO]" << "deleteing loaded kf." << endl;
+        delete kf;
 
-//    auto *ckf = colored_kDataFrame::load(index_prefix);
-    auto *kf = kDataFrame::load(index_prefix);
-//    auto *kf = ckf->getkDataFrame();
 
-    auto it = kf->begin();
-    while (it != kf->end()) {
-        colorsCount[it.getCount()]++;
-        it++;
-    }
-
-    // Free some memory
-    delete kf;
-
-    flat_hash_map<uint32_t, uint32_t> groupID_to_kmerCount;
-    for (const auto &record : color_to_ids) {
-        uint32_t colorCount = colorsCount[record.first];
-        for (auto group_id: record.second) {
-            groupID_to_kmerCount[group_id] += colorCount;
+        // Computing unique canonical kmer count from the colors and groups. 
+        cout << "[INFO]" << "kmer counting..." << endl;
+        flat_hash_map<uint32_t, uint32_t> groupID_to_kmerCount;
+        for (auto record : color_to_ids) {
+            uint32_t colorCount = colorsCount[record.first];
+            for (auto group_id : record.second) {
+                groupID_to_kmerCount[group_id] += colorCount;
+            }
         }
-    }
 
-    std::ofstream fstream_kmerCount;
-    fstream_kmerCount.open(index_prefix + "_kSpider_seqToKmersNo.tsv");
-    fstream_kmerCount << "ID\tseq\tkmers\n";
-    uint64_t counter = 0;
-    for(const auto & item : groupID_to_kmerCount){
-        fstream_kmerCount << ++counter << '\t' << item.first << '\t' << item.second << '\n';
-    }
-    fstream_kmerCount.close();
 
-    Combo combo = Combo();
-    flat_hash_map<std::pair<uint32_t, uint32_t>, uint32_t, boost::hash<pair<uint32_t, uint32_t>>> edges;
-    for (const auto &item : color_to_ids) {
-        combo.combinations(item.second.size());
-        for (auto const &seq_pair : combo.combs) {
-            uint32_t _seq1 = item.second[seq_pair.first];
-            uint32_t _seq2 = item.second[seq_pair.second];
-            _seq1 > _seq2 ? edges[{_seq1, _seq2}] += colorsCount[item.first] : edges[{_seq2,
-                                                                                      _seq1}] += colorsCount[item.first];
+        std::ofstream fstream_kmerCount;
+        fstream_kmerCount.open(index_prefix + "_kSpider_seqToKmersNo.tsv");
+        fstream_kmerCount << "ID\tseq\tkmers\n";
+        uint64_t counter = 0;
+        for (const auto& item : groupID_to_kmerCount) {
+            fstream_kmerCount << ++counter << '\t' << item.first << '\t' << item.second << '\n';
         }
+        fstream_kmerCount.close();
+
+        Combo combo = Combo();
+        flat_hash_map<std::pair<uint32_t, uint32_t>, uint32_t, boost::hash<pair<uint32_t, uint32_t>>> edges;
+        for (const auto& item : color_to_ids) {
+            combo.combinations(item.second.size());
+            for (auto const& seq_pair : combo.combs) {
+                uint32_t _seq1 = item.second[seq_pair.first];
+                uint32_t _seq2 = item.second[seq_pair.second];
+                _seq1 > _seq2 ? edges[{_seq1, _seq2}] += colorsCount[item.first] : edges[{_seq2,
+                    _seq1}] += colorsCount[item.first];
+            }
+        }
+
+
+        std::ofstream myfile;
+
+        myfile.open(index_prefix + "_kSpider_pairwise.tsv");
+
+        myfile << "ID" << '\t' << "seq1" << '\t' << "seq2" << '\t' << "shared_kmers" << '\n';
+
+        uint64_t line_count = 0;
+
+        for (const auto& edge : edges) {
+            myfile << ++line_count << '\t' << edge.first.first << '\t' << edge.first.second << '\t' << edge.second << '\n';
+        }
+
+        myfile.close();
+
     }
-
-
-    std::ofstream myfile;
-
-    myfile.open(index_prefix + "_kSpider_pairwise.tsv");
-
-    myfile << "ID" << '\t' << "seq1" << '\t' << "seq2" << '\t' << "shared_kmers" << '\n';
-
-    uint64_t line_count = 0;
-
-    for (const auto &edge : edges) {
-        myfile << ++line_count << '\t' << edge.first.first << '\t' << edge.first.second << '\t' << edge.second << '\n';
-    }
-
-    myfile.close();
-
-}
 }

--- a/src/swig_interfaces/kSpider_internal.i
+++ b/src/swig_interfaces/kSpider_internal.i
@@ -15,7 +15,8 @@ namespace kSpider{
     void index_protein(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix);
     void index_dayhoff(int kSize, string fasta_file, string names_file, int chunk_size, string index_prefix);
     void index_datasets(string kfs_dir);
-    void paired_end_to_kDataFrame(string r1_file_name, string r2_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones);
-    void single_end_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, int downsampling_ration, bool remove_singletones);
-    void protein_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, bool is_dayhoff, string output_prefix, int downsampling_ration = 1);
+    void datasets_indexing(string kfs_dir);
+    void paired_end_to_kDataFrame(string r1_file_name, string r2_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones, bool ondisk);
+    void single_end_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, int downsampling_ratio, bool remove_singletones, bool ondisk);
+    void protein_to_kDataFrame(string r1_file_name, int kSize, int chunk_size, bool is_dayhoff, string output_prefix, int downsampling_ratio, bool ondisk);
 };


### PR DESCRIPTION
This PR will introduce integrating kProcessor2 into kSpider.

- [ ] Write tests for pairwise containment.
- [x] Add options for on-disk buffering using buffered MQF.
- [x] Convert sketching code to use the new kDataFrameFactory class.
- [x] Add priority queue indexing option (should have another UX-friendly name).
- [x] Modify the current indexing function to migrate the new changes in v2.
- [ ] Benchmark against the branch::master.